### PR TITLE
Added the the ability to set a custom class name for the date-picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 target/
 /nbproject/*
 .vscode
+.DS_Store

--- a/src/dhis2.angular.directives.js
+++ b/src/dhis2.angular.directives.js
@@ -305,9 +305,11 @@ var d2Directives = angular.module('d2Directives', [])
             var minDate = $parse(attrs.minDate)(scope);
             var maxDate = $parse(attrs.maxDate)(scope);
             var calendar = $.calendars.instance(calendarSetting.keyCalendar);
+            var pickerClass = attrs.pickerClass;
 
             var initializeDatePicker = function( sDate, eDate ){
                 element.calendarsPicker({
+                    pickerClass: pickerClass,
                     changeMonth: true,
                     dateFormat: dateFormat,
                     yearRange: '-120:+30',


### PR DESCRIPTION
- This makes it easy to add custom class names to the date-picker.

- This is handy when you, for instance, want to change the CSS-style for only one specific date-picker.

**Example (picker-class attribute adds the custom class name):**
```html
<input type="text"
               placeholder="{{dhis2CalendarFormat.keyDateFormat}}"
               class="form-control hideInPrint"
               ng-class="{'input-success': eventDateSaved}"
               d2-date-validator
               d2-date
               max-date="model.maxDate?model.maxDate : '0'"
               min-date="model.minDate?model.minDate : ''"
               picker-class="hide-clear"
               name="eventDate"
               ng-model="currentEvent.eventDate"
               ng-change="verifyExpiryDate(currentEvent.eventDate)"
               ng-disabled="selectedOrgUnit.closedStatus || currentEvent.status === 'SKIPPED' || selectedEnrollment.status !== 'ACTIVE' || currentEvent.editingNotAllowed || currentStage.periodType"
               ng-required="true"
               blur-or-change="saveEventDate()"/>
```

Since we now have added a custom class name to the date picker, we can make a custom CSS script. In this case, we want to hide the _clear date_ button:
```css
.hide-clear .ui-datepicker-cmd-clear {
    display: none;
}
```